### PR TITLE
Install project scaffolding using Eask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Byte-code
+*.elc
+
+# Packaging
+.eask/
+
+# Distribution
+dist/
+
+# Eask might be installed within the project.
+node_modules/
+package-lock.json
+package.json

--- a/Eask
+++ b/Eask
@@ -1,0 +1,17 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
+(package "renpy"
+         "0.3"
+         "Major mode for editing Ren'Py files")
+
+(website-url "https://github.com/Reagankm/renpy-mode")
+(keywords "languages")
+
+(package-file "renpy.el")
+
+(script "test" "echo \"Error: no test specified\" && exit 1")
+
+;;; Avoid anything non-gnu as dependencies
+(source "gnu")
+
+(depends-on "emacs" "27.1")

--- a/Eask
+++ b/Eask
@@ -11,7 +11,7 @@
 
 (script "test" "echo \"Error: no test specified\" && exit 1")
 
-;;; Avoid anything non-gnu as dependencies
+;; Avoid anything non-gnu as dependencies.
 (source "gnu")
 
 (depends-on "emacs" "27.1")

--- a/TODO.org
+++ b/TODO.org
@@ -1,0 +1,55 @@
+* Testing
+
+- [ ] which-func tests
+
+- [ ] more imenu tests
+
+- [ ] movement tests
+
+- [ ] indentation tests
+
+- [ ] font-locking tests
+
+- [ ] automated testing with multiple emacs versions
+
+* Font lock
+
+- [ ] local label syntax highlight
+
+* Xref support
+
+- [ ] file-local symbol lookup
+
+- [ ] global symbol lookup
+
+- [ ] symbol reference search
+
+* Completion
+
+See https://github.com/renpy/vscode-language-renpy/blob/master/src/completion.ts for
+inspiration:
+
+- [ ] local/global label completion
+
+- [ ] keyword-specific completions
+
+* Integration
+
+- [ ] Ren'py launcher integration (see https://github.com/elizagamedev/renpy-mode)
+
+- [ ] Suggest for inclusion?
+
+* Document
+
+- [ ] Existing facilities
+
+- [ ] Launcher integration
+
+- [ ] Contribution
+
+
+* Publishing
+
+- [ ] rename to renpy-mode (also in Melpa)
+
+- [ ] reannounce the package (once enough features are ready)

--- a/TODO.org
+++ b/TODO.org
@@ -55,7 +55,6 @@ inspiration:
 
 - [ ] Contribution
 
-
 * Publishing
 
 - [ ] rename to renpy-mode (also in Melpa)

--- a/TODO.org
+++ b/TODO.org
@@ -1,20 +1,28 @@
 * Testing
 
-- [ ] which-func tests
+- [X] more imenu tests
 
-- [ ] more imenu tests
+  - [X] defines/defaults in imenu
+
+  - [X] cover everything
+
+- [-] font-locking tests with ert-font-lock
+
+  - [X] setup the tests for emacs 30 only
+
+  - [ ] ren'py statements
+
+  - [ ] python blocks
+
+  - [ ] inline python?
+
+- [ ] which-func tests
 
 - [ ] movement tests
 
 - [ ] indentation tests
 
-- [ ] font-locking tests
-
 - [ ] automated testing with multiple emacs versions
-
-* Font lock
-
-- [ ] local label syntax highlight
 
 * Xref support
 

--- a/renpy.el
+++ b/renpy.el
@@ -58,11 +58,7 @@
 		  (0+ (or alphanumeric "_"))
 		  symbol-end))
 	    (label-name
-	     (seq (optional ".")
-		  symbol-start
-		  (or alpha "_")
-		  (0+ (or alphanumeric "_"))
-		  symbol-end))
+	     (seq (optional ".") name))
 	    (image-name
 	     (seq symbol-start
 		  (1+ (or alphanumeric "_"))

--- a/renpy.el
+++ b/renpy.el
@@ -57,6 +57,12 @@
 		  (or alpha "_")
 		  (0+ (or alphanumeric "_"))
 		  symbol-end))
+	    (label-name
+	     (seq (optional ".")
+		  symbol-start
+		  (or alpha "_")
+		  (0+ (or alphanumeric "_"))
+		  symbol-end))
 	    (image-name
 	     (seq symbol-start
 		  (1+ (or alphanumeric "_"))
@@ -364,7 +370,7 @@
 	  symbol-end)
      . font-lock-builtin-face)
     ;; Ren'Py 8.0.3
-    (,(renpy-rx (group label-keyword) (1+ space) (group name))
+    (,(renpy-rx (group label-keyword) (1+ space) (group label-name))
      (1 font-lock-keyword-face) (2 font-lock-function-name-face))
     (,(renpy-rx (group screen-keyword) (1+ space) (group name))
      (1 font-lock-keyword-face) (2 font-lock-function-name-face))
@@ -1299,7 +1305,7 @@ don't move and return nil.  Otherwise return t."
 ;;;; Imenu.
 
 (defvar renpy-generic-imenu
-  `((nil ,(renpy-rx label-keyword (1+ space) (group name)) 1)
+  `((nil ,(renpy-rx label-keyword (1+ space) (group label-name)) 1)
     ("/class" ,(renpy-rx symbol-start "class" (1+ space) (group name)) 1)
     ("/function" ,(renpy-rx symbol-start "def" (1+ space) (group name)) 1)
     ("/image" ,(renpy-rx image-keyword (1+ space) (group name)) 1)

--- a/renpy.el
+++ b/renpy.el
@@ -83,10 +83,12 @@
 	    ;; Images.
 	    (image-keyword
 	     (seq line-start "image" symbol-end))
-	    ;; Define or default.  Allow indentation for use in explicit init
-	    ;; blocks or within a screen.
-	    (default-or-define-keyword
-	      (seq line-start (0+ space) (or "default" "define") symbol-end))
+	    ;; Define and default. Both allow indentation for use in explicit
+	    ;; init blocks or within a screen.
+	    (define-keyword
+	     (seq line-start (0+ space) "define" symbol-end))
+	    (default-keyword
+	     (seq line-start (0+ space) "default" symbol-end))
 	    ;; Init.
 	    (init-keyword
 	     (seq line-start "init" symbol-end))
@@ -386,7 +388,7 @@
 	(search-forward-regexp "=" (line-end-position) t))
       nil
       (0 font-lock-preprocessor-face)))
-    (,(renpy-rx default-or-define-keyword)
+    (,(renpy-rx (or default-keyword define-keyword))
      (0 font-lock-keyword-face)
      ;; Anchored match for anything that looks like a valid name.
      (,(renpy-rx name)
@@ -1311,7 +1313,9 @@ don't move and return nil.  Otherwise return t."
     ("/image" ,(renpy-rx image-keyword (1+ space) (group name)) 1)
     ("/screen" ,(renpy-rx screen-keyword (1+ space) (group name)) 1)
     ("/style" ,(renpy-rx style-keyword (1+ space) (group name)) 1)
-    ("/transform" ,(renpy-rx transform-keyword (1+ space) (group name)) 1)))
+    ("/transform" ,(renpy-rx transform-keyword (1+ space) (group name)) 1)
+    ("/define" ,(renpy-rx define-keyword (1+ space) (group name)) 1)
+    ("/default" ,(renpy-rx default-keyword (1+ space) (group name)) 1)))
 
 ;;;; `Electric' commands.
 

--- a/test/renpy-font-lock-test.el
+++ b/test/renpy-font-lock-test.el
@@ -1,0 +1,20 @@
+;;; renpy-font-lock-test.el ---                     -*- lexical-binding: t; -*-
+
+;;; Code:
+
+(require 'ert)
+(require 'renpy)
+
+; NOTE: ert-font-lock was only introduced in Emacs 30
+(when (>= emacs-major-version 30)
+  (require 'ert-font-lock)
+  (ert-font-lock-deftest test-renpy-font-lock-basic renpy-mode
+    "
+label start:
+# <- font-lock-keyword-face
+#^^^^font-lock-keyword-face
+#     ^^^^^ font-lock-function-name-face
+    say \"Hello, World!\"
+"))
+
+;;; renpy-font-lock-test.el ends here

--- a/test/renpy-font-lock-test.el
+++ b/test/renpy-font-lock-test.el
@@ -15,6 +15,10 @@ label start:
 #^^^^font-lock-keyword-face
 #     ^^^^^ font-lock-function-name-face
     say \"Hello, World!\"
+
+label .local_label:
+#     ^^^^^^^^^^^^ font-lock-function-name-face
+    pass
 "))
 
 ;;; renpy-font-lock-test.el ends here

--- a/test/renpy-font-lock-test.el
+++ b/test/renpy-font-lock-test.el
@@ -5,7 +5,7 @@
 (require 'ert)
 (require 'renpy)
 
-; NOTE: ert-font-lock was only introduced in Emacs 30
+;; NOTE: ert-font-lock was only introduced in Emacs 30.
 (when (>= emacs-major-version 30)
   (require 'ert-font-lock)
   (ert-font-lock-deftest test-renpy-font-lock-basic renpy-mode

--- a/test/renpy-test.el
+++ b/test/renpy-test.el
@@ -5,7 +5,7 @@
 (require 'ert)
 (require 'renpy)
 
-(ert-deftest test-renpy-imenu ()
+(ert-deftest test-renpy-imenu-basic ()
   (with-temp-buffer-str
       "
 # comment
@@ -15,6 +15,30 @@ label start:
     (let ((index-alist (funcall imenu-create-index-function)))
       (should (equal (length index-alist) 1))
       (should (alist-get "start" index-alist nil nil #'string-equal)))))
+
+(ert-deftest test-renpy-imenu-multiple ()
+  (with-temp-buffer-str
+      "
+# comment
+label first:
+    say \"first label\"
+
+label second_label:
+    say \"second label\"
+
+label .local_label:
+    say \"local label\"
+
+label label_with_params(a):
+    say \"paremetrized label\"
+
+"
+    (let ((index-alist (funcall imenu-create-index-function)))
+      (should (equal (length index-alist) 4))
+      (should (alist-get "first" index-alist nil nil #'string-equal))
+      (should (alist-get "second_label" index-alist nil nil #'string-equal))
+      (should (alist-get ".local_label" index-alist nil nil #'string-equal))
+      (should (alist-get "label_with_params" index-alist nil nil #'string-equal)))))
 
 (provide 'renpy-test)
 ;;; renpy-test.el ends here

--- a/test/renpy-test.el
+++ b/test/renpy-test.el
@@ -5,6 +5,10 @@
 (require 'ert)
 (require 'renpy)
 
+;;;; Imenu tests
+
+;TODO: figure out proper imenu names
+
 (ert-deftest test-renpy-imenu-basic ()
   (with-temp-buffer-str
       "
@@ -39,6 +43,76 @@ label label_with_params(a):
       (should (alist-get "second_label" index-alist nil nil #'string-equal))
       (should (alist-get ".local_label" index-alist nil nil #'string-equal))
       (should (alist-get "label_with_params" index-alist nil nil #'string-equal)))))
+
+(ert-deftest test-renpy-imenu-style-transform ()
+  (with-temp-buffer-str
+      "
+style button:
+    background \"button.png\"
+
+transform fade_in:
+    alpha 0.0
+    linear 0.5 alpha 1.0
+"
+    (let* ((index-alist (funcall imenu-create-index-function))
+	  (style-alist (alist-get "/style" index-alist nil nil #'string-equal))
+	  (transform-alist (alist-get "/transform" index-alist nil nil #'string-equal)))
+      (should (equal (length index-alist) 2))
+      (should style-alist)
+      (should transform-alist)
+      (should (alist-get "button" style-alist nil nil #'string-equal))
+      (should (alist-get "fade_in" transform-alist nil nil #'string-equal)))))
+
+(ert-deftest test-renpy-imenu-screen-image ()
+  (with-temp-buffer-str
+      "
+screen main_menu():
+    textbutton \"Start Game\" action Start()
+
+image eileen happy = \"eileen_happy.png\"
+"
+    (let* ((index-alist (funcall imenu-create-index-function))
+	   (screen-alist (alist-get "/screen" index-alist nil nil #'string-equal))
+	   (image-alist (alist-get "/image" index-alist nil nil #'string-equal)))
+      (should (equal (length index-alist) 2))
+      (should screen-alist)
+      (should image-alist)
+      (should (alist-get "main_menu" screen-alist nil nil #'string-equal))
+      (should (alist-get "eileen" image-alist nil nil #'string-equal)))))
+
+(ert-deftest test-renpy-imenu-class-function ()
+  (with-temp-buffer-str
+      "
+init python:
+    class MyClass(object):
+        def method(self):
+            pass
+
+def my_function(param):
+    return param
+"
+    (let* ((index-alist (funcall imenu-create-index-function))
+	   (class-alist (alist-get "/class" index-alist nil nil #'string-equal))
+	   (function-alist (alist-get "/function" index-alist nil nil #'string-equal)))
+      (should (equal (length index-alist) 2))
+      (should class-alist)
+      (should function-alist)
+      (should (alist-get "MyClass" class-alist nil nil #'string-equal))
+      (should (alist-get "my_function" function-alist nil nil #'string-equal)))))
+
+(ert-deftest test-renpy-imenu-define-default ()
+  (with-temp-buffer-str
+      "
+define character = Character('Eileen')
+default points = 0
+"
+    (let* ((index-alist (funcall imenu-create-index-function))
+	   (define-alist (alist-get "/define" index-alist nil nil #'string-equal))
+	   (default-alist (alist-get "/default" index-alist nil nil #'string-equal)))
+      (should (equal (length index-alist) 2))
+      (should (alist-get "character" define-alist nil nil #'string-equal))
+      (should (alist-get "points" default-alist nil nil #'string-equal)))))
+
 
 (provide 'renpy-test)
 ;;; renpy-test.el ends here

--- a/test/renpy-test.el
+++ b/test/renpy-test.el
@@ -7,7 +7,7 @@
 
 ;;;; Imenu tests
 
-; TODO: figure out proper imenu names
+;; TODO: Figure out proper imenu names.
 
 (ert-deftest test-renpy-imenu-basic ()
   (with-temp-buffer-str

--- a/test/renpy-test.el
+++ b/test/renpy-test.el
@@ -1,0 +1,20 @@
+;;; renpy-test.el ---                                -*- lexical-binding: t; -*-
+
+;;; Code:
+
+(require 'ert)
+(require 'renpy)
+
+(ert-deftest test-renpy-imenu ()
+  (with-temp-buffer-str
+      "
+# comment
+label start:
+    say \"This is a test\"
+"
+    (let ((index-alist (funcall imenu-create-index-function)))
+      (should (equal (length index-alist) 1))
+      (should (alist-get "start" index-alist nil nil #'string-equal)))))
+
+(provide 'renpy-test)
+;;; renpy-test.el ends here

--- a/test/renpy-test.el
+++ b/test/renpy-test.el
@@ -7,7 +7,7 @@
 
 ;;;; Imenu tests
 
-;TODO: figure out proper imenu names
+; TODO: figure out proper imenu names
 
 (ert-deftest test-renpy-imenu-basic ()
   (with-temp-buffer-str

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,0 +1,12 @@
+;;; test-helper.el --- Helpers                       -*- lexical-binding: t; -*-
+
+(defmacro with-temp-buffer-str (str &rest body)
+  "Eval BODY within a buffer with containing STR. "
+  (declare (indent 1) (debug t))
+  `(with-temp-buffer
+     (insert ,str)
+     (renpy-mode)
+     (goto-char (point-min))
+     ,@body))
+
+;;; test-helper.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,7 +1,13 @@
 ;;; test-helper.el --- Helpers                       -*- lexical-binding: t; -*-
 
+;; NOTE: test/test-helper.el is always loaded by ert-runner prior to running
+;; unit tests. If manual test run is necessary then this file has to be loaded
+;; manually.
+
+;;; Code:
+
 (defmacro with-temp-buffer-str (str &rest body)
-  "Eval BODY within a buffer with containing STR. "
+  "Eval BODY within a buffer with containing STR."
   (declare (indent 1) (debug t))
   `(with-temp-buffer
      (insert ,str)


### PR DESCRIPTION
Hi @morganwillcock ,

This PR is setting some generic project management through [Eask](https://emacs-eask.github.io/). It also adds a few unit tests for renpy-mode's imenu support and makes sure local labels are listed in the menu as well.

The intention is to make testing multiple Emacs version easy. Having a test suite and a central place to define dependencies is a first step here.

Let me know if you have any objections to this setup.