### PR TITLE
Buffer-local context-aware label completion

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -10,7 +10,7 @@
 
   - [X] setup the tests for emacs 30 only
 
-  - [ ] ren'py statements
+  - [X] ren'py statements
 
   - [ ] python blocks
 

--- a/TODO.org
+++ b/TODO.org
@@ -37,9 +37,11 @@
 See https://github.com/renpy/vscode-language-renpy/blob/master/src/completion.ts for
 inspiration:
 
-- [ ] local/global label completion
+- [X] local label completion
 
-- [ ] keyword-specific completions
+- [ ] global label completion
+
+- [ ] keyword completions
 
 * Integration
 

--- a/test/renpy-completion-test.el
+++ b/test/renpy-completion-test.el
@@ -1,0 +1,94 @@
+;;; renpy-completion-test.el ---                        -*- lexical-binding: t; -*-
+
+;;; Code:
+
+(require 'ert)
+(require 'renpy)
+
+;;;; Completion contexts
+
+(renpy-test-context call-label
+  "call |" :label)
+
+(renpy-test-context jump-label
+  "jump |" :label)
+
+(renpy-test-context show-image
+  "show |" :image)
+
+(renpy-test-context scene-image
+  "scene |" :image)
+
+(renpy-test-context hide-image
+  "hide |" :image)
+
+(renpy-test-context at-transform
+  "at |" :transform)
+
+(renpy-test-context default
+  "bla bla |" :none)
+
+;;;; Local label completion
+
+(ert-deftest test-renpy-completion-collect-labels ()
+  (with-temp-buffer-str
+      "
+label start:
+    pass
+
+label global_label:
+   pass
+
+label .local_label:
+   pass
+"
+    (let ((labels (renpy--collect-labels)))
+      (should (equal (length labels) 3))
+      (should (member "start" labels))
+      (should (member "global_label" labels))
+      (should (member ".local_label" labels)))))
+
+(renpy-test-capf none
+  "
+label start:
+    pass
+
+label other:
+    pass
+
+label .local:
+    pass | # invalid context
+"
+  ())
+
+(renpy-test-capf jump-label
+  "
+label start:
+    pass
+
+label other:
+    pass
+
+label .local:
+    pass
+
+jump st|
+"
+  ("start" "other" ".local"))
+
+(renpy-test-capf call-label
+  "
+label start:
+    pass
+
+label other:
+    pass
+
+label .local:
+    pass
+
+call st|
+"
+  ("start" "other" ".local"))
+
+;;; renpy-completion-test.el ends here

--- a/test/renpy-font-lock-test.el
+++ b/test/renpy-font-lock-test.el
@@ -8,6 +8,11 @@
 ;; NOTE: ert-font-lock was only introduced in Emacs 30.
 (when (>= emacs-major-version 30)
   (require 'ert-font-lock)
+  ;; TODO: Atomic tests below should be accompanied with a single example file
+  ;; imported from Ren'py.
+
+;;;; Ren'py Keywords
+
   (ert-font-lock-deftest test-renpy-font-lock-basic renpy-mode
     "
 label start:
@@ -19,6 +24,53 @@ label start:
 label .local_label:
 #     ^^^^^^^^^^^^ font-lock-function-name-face
     pass
+")
+
+  (ert-font-lock-deftest test-renpy-font-lock-jump-call renpy-mode
+    "
+label start:
+    call random_label
+#   ^^^^ font-lock-keyword-face
+
+    jump other_chapter
+#   ^^^^ font-lock-keyword-face
+")
+
+  (ert-font-lock-deftest test-renpy-font-lock-image renpy-mode
+    "
+image eileen = \"eileen_happy.png\"
+# <- font-lock-keyword-face
+#^^^^ font-lock-keyword-face
+#     ^^^^^^ font-lock-variable-name-face
+
+image eileen happy wet = \"eileen_happy.png\"
+# <- font-lock-keyword-face
+#^^^^ font-lock-keyword-face
+#     ^^^^^^ font-lock-variable-name-face
+#            ^^^^^ font-lock-preprocessor-face
+#                  ^^^ font-lock-preprocessor-face
+")
+
+  (ert-font-lock-deftest test-renpy-font-lock-show-hide renpy-mode
+    "
+show eileen happy with dissolve
+# <- font-lock-keyword-face
+#^^^              ^^^^ font-lock-keyword-face
+
+show eileen happy at left with move
+# <- font-lock-keyword-face
+#^^^              ^^      ^^^^ font-lock-keyword-face
+
+hide eileen with dissolve
+# <- font-lock-keyword-face
+#^^^        ^^^^ font-lock-keyword-face
+")
+
+  (ert-font-lock-deftest test-renpy-font-lock-scene renpy-mode
+    "
+scene bg whitehouse with fade
+# <- font-lock-keyword-face
+#^^^^               ^^^^ font-lock-keyword-face
 "))
 
 ;;; renpy-font-lock-test.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -15,4 +15,33 @@
      (goto-char (point-min))
      ,@body))
 
+(defmacro renpy-test-context (name code expected)
+  "Create an ERT test called NAME.
+CODE is a code fragment where ‘|’ marks the point where completion is
+requested. EXPECTED is the keyword symbol that
+`renpy--completion-context' should return."
+  (declare (indent 1) (debug t))
+  `(ert-deftest ,(intern (format "test-renpy-completion-context-%s" name)) ()
+     (with-temp-buffer-str ,code
+       (search-forward "|" nil t)
+       (delete-char -1)
+       (should (equal (renpy--completion-context) ,expected)))))
+
+(defmacro renpy-test-capf (name code expected-cands)
+  "Run CAPF in CODE fragment, expect EXPECTED-CANDS list.
+In CODE ‘|’ marks the point where completion is requested. If
+EXPECTED-CANDS is nil we assert that the CAPF returns nil."
+  (declare (indent 1) (debug t))
+  `(ert-deftest ,(intern (format "test-renpy-completion-capf-%s" name)) ()
+     (with-temp-buffer-str ,code
+       (search-forward "|" nil t)
+       (delete-char -1)
+       (let ((capf (renpy-completion-at-point)))
+         ,(if expected-cands
+              `(progn
+                 (should capf)
+                 (should (equal (sort (nth 2 capf) #'string<)
+                                (sort ',expected-cands #'string<))))
+            `(should (null capf)))))))
+
 ;;; test-helper.el ends here


### PR DESCRIPTION
NOTE: this is supposed to be merged after #6 

This branch is our first interesting changes to renpy-mode.

### Background and motivation

While working on my little novellete I realised how I often need to lookup relevant labels whenever I use call/jump Ren'py statements.

I took a look at how VS code does completion (https://github.com/renpy/vscode-language-renpy/blob/master/src/completion.ts). There's nothing too fancy, just understand context + lookup relevant symbols. It feels like it should be really easy ot replicate in Emacs.

### Implementation

This PR sets the framework for building context-aware completion in renpy-mode. This is a first approximation of what is to come in later PRs. 

Note that only *buffer-local* label completion provided in call/jump statements for now.

Key points to notice:

1. (renpy--completion-context) retrieves the completion context at point.
2. (renpy--collect-labels) builds a buffer-local label completion table.
3. (renpy-completion-at-point) puts everything together.
4. A customization option renpy-setup-completion is provided.

Happy to discuss!