### PR TITLE
Rename to renpy-mode

### DIFF
--- a/Eask
+++ b/Eask
@@ -1,13 +1,13 @@
 ;; -*- mode: eask; lexical-binding: t -*-
 
-(package "renpy"
+(package "renpy-mode"
          "0.3"
          "Major mode for editing Ren'Py files")
 
 (website-url "https://github.com/Reagankm/renpy-mode")
 (keywords "languages")
 
-(package-file "renpy.el")
+(package-file "renpy-mode.el")
 
 (script "test" "echo \"Error: no test specified\" && exit 1")
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 EMACS = emacs
 RM = rm -f
 
-compile: renpy.elc
+compile: renpy-mode.elc
 
 .el.elc:
 	$(EMACS) --batch --quick \
@@ -12,4 +12,4 @@ compile: renpy.elc
 	    --funcall batch-byte-compile $<
 
 clean:
-	$(RM) renpy.elc
+	$(RM) renpy-mode.elc

--- a/README.org
+++ b/README.org
@@ -4,11 +4,11 @@ A major mode for editing Ren'Py files.
 
 ** Installation
 
-Either install the ~renpy~ package from within Emacs directly from MELPA or:
+Either install the ~renpy-mode~ package from within Emacs directly from MELPA or:
 
 - Download/clone this repo to your desired location.
 
-- In Emacs, use the ~package-install-file~ command and point it to the renpy.el
+- In Emacs, use the ~package-install-file~ command and point it to the renpy-mode.el
   file location.
 
 ** Features
@@ -34,7 +34,7 @@ Either install the ~renpy~ package from within Emacs directly from MELPA or:
 Example configuration with the ~use-package~ macro:
 
 #+begin_src emacs-lisp
-  (use-package renpy
+  (use-package renpy-mode
     ;; Install the package unless installed already.
     :ensure t
     ;; Uncomment and tweak if renpy-mode was downloaded into a custom.

--- a/TODO.org
+++ b/TODO.org
@@ -159,8 +159,8 @@ Key VSCode plugin implementation points:
 
 * Publishing
 
-- [ ] rename to renpy-mode (also in Melpa)
+- [X] rename to renpy-mode
 
-- [ ] update the README
+- [X] update README.org
 
 - [ ] reannounce the package (once enough features are ready)

--- a/renpy-mode.el
+++ b/renpy-mode.el
@@ -1,4 +1,4 @@
-;;; renpy.el --- Major mode for editing Ren'Py files -*- lexical-binding: t; -*-
+;;; renpy-mode.el --- Major mode for editing Ren'Py files -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2013
 ;;   Free Software Foundation, Inc.
@@ -2387,6 +2387,6 @@ effect outside them.
 (custom-add-option 'renpy-mode-hook 'imenu-add-menubar-index)
 (custom-add-option 'renpy-mode-hook 'abbrev-mode)
 
-(provide 'renpy)
+(provide 'renpy-mode)
 
-;;; renpy.el ends here
+;;; renpy-mode.el ends here

--- a/test/renpy-capf-test.el
+++ b/test/renpy-capf-test.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (require 'ert)
-(require 'renpy)
+(require 'renpy-mode)
 
 ;;;; Label completion.
 

--- a/test/renpy-context-test.el
+++ b/test/renpy-context-test.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (require 'ert)
-(require 'renpy)
+(require 'renpy-mode)
 
 ;;;; Call statement.
 

--- a/test/renpy-flymake-test.el
+++ b/test/renpy-flymake-test.el
@@ -8,7 +8,7 @@
 
 (require 'ert)
 (require 'flymake)
-(require 'renpy)
+(require 'renpy-mode)
 
 (ert-deftest renpy--parse-lint-buffer-test ()
   (let ((output-buffer (generate-new-buffer "*renpy-lint-output*")))

--- a/test/renpy-font-lock-test.el
+++ b/test/renpy-font-lock-test.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (require 'ert)
-(require 'renpy)
+(require 'renpy-mode)
 
 ;; NOTE: ert-font-lock was only introduced in Emacs 30.
 (when (>= emacs-major-version 30)

--- a/test/renpy-imenu-test.el
+++ b/test/renpy-imenu-test.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (require 'ert)
-(require 'renpy)
+(require 'renpy-mode)
 
 ;; TODO: Figure out proper imenu names.
 

--- a/test/renpy-symbol-bounds-test.el
+++ b/test/renpy-symbol-bounds-test.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (require 'ert)
-(require 'renpy)
+(require 'renpy-mode)
 
 (renpy-test-bounds test-renpy-find-symbol-bounds
   "   test_symbol   "

--- a/test/renpy-symbol-collect-test.el
+++ b/test/renpy-symbol-collect-test.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (require 'ert)
-(require 'renpy)
+(require 'renpy-mode)
 
 (ert-deftest test-renpy-collect-labels ()
   (with-temp-buffer-str

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -9,7 +9,7 @@
 ;;; Code:
 
 (require 'ert)
-(require 'renpy)
+(require 'renpy-mode)
 
 (defmacro with-temp-buffer-str (str &rest body)
   "Eval BODY within a buffer with containing STR."


### PR DESCRIPTION
Hi @morganwillcock ,

Bookkeeping:

1. Rename the package to renpy-mode for consistency with other major modes.
2. ~~Bump package's version to 0.4 to reflect the amount of accumulated changes~~.

I'll also submit an update to the Melpa recipe to reflect name changes once this branch is merged.